### PR TITLE
strip comments / blank lines

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -62,9 +62,23 @@ int main(int argc, char *argv[]) {
     while (!input.eof()) {
         line_no++;
         getline(input, line);
+
+	// Strip any comments that start with ; to the end of the line
+	const size_t comment_start = line.find_first_of(';');
+	if (comment_start != std::string::npos) {
+		line.resize(comment_start);
+	}
+
+	// Now, strip away any trailing spaces
         while (!line.empty() && isspace(line[line.size()-1])) {
             line.resize(line.length()-1);
         }
+
+	// If the line is empty, then skip it
+	if (line.empty()) {
+		continue;
+	}
+
         fprintf(stderr, "%4d| %s ", line_no, line.c_str());
         fflush(stderr);
         line.append("\n");  // GRBL wants only newline, not CRLF


### PR DESCRIPTION
This does two things:

* strips comments that start with ; - eg what cura spits out
  when generating g-code
* skips blank lines entirely - super useful if a comment is the
  only thing on a line